### PR TITLE
Fix Superalloy Plating's Vanilla Recipe Being Overridden

### DIFF
--- a/ProjectSquirrel/advtech/sq_nano_generic_comp.json
+++ b/ProjectSquirrel/advtech/sq_nano_generic_comp.json
@@ -222,6 +222,7 @@
   },
   {
     "result": "alloy_plate",
+    "id_suffix": "nanotech",
     "type": "recipe",
     "category": "CC_첨단기술",
     "subcategory": "CSC_첨단기술_MATERIALS",


### PR DESCRIPTION
Because there wasn't an id_suffix, this recipe was overriding the vanilla recipe for welding a superalloy plating together out of superalloy sheets.

And yes, I realize this version of the mod hasn't gotten updated in a few months since the author is in the military. It'll be fine to wait until they get back.