### PR TITLE
buff: sq_frame_backpack

### DIFF
--- a/ProjectSquirrel/items/sq_cargo_frame.json
+++ b/ProjectSquirrel/items/sq_cargo_frame.json
@@ -161,10 +161,21 @@
     "coverage": 30,
     "rigid": false,
     "encumbrance": 3,
-    "max_encumbrance": 15,
+    "max_encumbrance": 10,
     "weight_capacity_modifier": 1.5,
     "warmth": 1,
     "material_thickness": 3,
+    "use_action": {
+      "type": "holster",
+      "holster_prompt": "Stow gear",
+      "holster_msg": "You stow your %s",
+      "min_volume": "250ml",
+      "max_volume": "2500ml",
+      "multi": 2,
+      "draw_cost": 120,
+      "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD", "SHEATH_AXE", "MAG_COMPACT", "MAG_BULKY", "MAG_BELT", "SPEEDLOADER", "BELT_CLIP" ],
+      "skills": [ "pistol", "smg", "shotgun", "rifle", "launcher" ]
+    },
     "flags": [ "BELTED" ]
   },
   {

--- a/ProjectSquirrel/items/sq_cargo_frame.json
+++ b/ProjectSquirrel/items/sq_cargo_frame.json
@@ -161,7 +161,7 @@
     "coverage": 30,
     "rigid": false,
     "encumbrance": 3,
-    "max_encumbrance": 10,
+    "max_encumbrance": 15,
     "weight_capacity_modifier": 1.5,
     "warmth": 1,
     "material_thickness": 3,


### PR DESCRIPTION
The `frame pack`, despite having a 1.5x multiplier to the player's carrying capacity, still leaves something to be desired, as its encumbrance is much higher than that of the `molle_pack` and it lacks a `holster`.

Minor changes I made:

1. ~~Slightly reduced the encumbrance.~~
2. Added a `holster` to the backpack.