### PR TITLE
feat: add "CAN_BE_ORDERED" flag to flying drones

### DIFF
--- a/ProjectSquirrel/monsters/sq_drones.json
+++ b/ProjectSquirrel/monsters/sq_drones.json
@@ -112,7 +112,7 @@
       }
     ],
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "ELECTRONIC", "ELECTRIC", "COLDPROOF", "NO_BREATHE", "FLIES", "PRIORITIZE_TARGETS", "HIT_AND_RUN", "HARDTOSHOOT", "PET_HARNESSABLE" ]
+    "flags": [ "SEES", "HEARS", "ELECTRONIC", "ELECTRIC", "COLDPROOF", "NO_BREATHE", "FLIES", "PRIORITIZE_TARGETS", "HIT_AND_RUN", "HARDTOSHOOT", "PET_HARNESSABLE", "CAN_BE_ORDERED" ]
   },
   {
     "id": "bot_sq_gun_drone",
@@ -227,7 +227,7 @@
     ],
     "death_drops": { "groups": [ [ "robots", 4 ], [ "manhack", 1 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "ELECTRONIC", "ELECTRIC", "COLDPROOF", "NO_BREATHE", "FLIES", "PRIORITIZE_TARGETS", "HIT_AND_RUN", "HARDTOSHOOT", "PET_HARNESSABLE" ]
+    "flags": [ "SEES", "HEARS", "ELECTRONIC", "ELECTRIC", "COLDPROOF", "NO_BREATHE", "FLIES", "PRIORITIZE_TARGETS", "HIT_AND_RUN", "HARDTOSHOOT", "PET_HARNESSABLE", "CAN_BE_ORDERED" ]
   },
   {
     "id": "bot_sq_gun_drone_2",
@@ -341,7 +341,7 @@
       }
     ],
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "ELECTRONIC", "ELECTRIC", "COLDPROOF", "NO_BREATHE", "LOUDMOVES", "FLIES", "PRIORITIZE_TARGETS", "PET_HARNESSABLE" ]
+    "flags": [ "SEES", "HEARS", "ELECTRONIC", "ELECTRIC", "COLDPROOF", "NO_BREATHE", "LOUDMOVES", "FLIES", "PRIORITIZE_TARGETS", "PET_HARNESSABLE", "CAN_BE_ORDERED" ]
   },
   {
     "id": "bot_sq_emp_drone",


### PR DESCRIPTION
The flag allows you to order drones (in 'e'xamine menu) to follow you instead of rushing enemies. They still shoot said enemies.